### PR TITLE
Rewrite event loops to offer a processEvents-type interface.

### DIFF
--- a/include/backend/backend.h
+++ b/include/backend/backend.h
@@ -30,14 +30,33 @@ RENGINE_BEGIN_NAMESPACE
 class Backend
 {
 public:
+    Backend() : m_running(true) { }
     virtual ~Backend() { }
 
     static Backend *get();
 
     virtual void quit() = 0;
-    virtual void run() = 0;
+    void run();
+    virtual void processEvents() = 0;
     virtual Surface *createSurface(SurfaceInterface *) = 0;
     virtual Renderer *createRenderer(Surface *surface) = 0;
+
+    bool m_running;
 };
+
+inline void Backend::run()
+{
+    if (!m_running) {
+        logd << "quit() already called, not starting eventloop.." << std::endl;
+    } else  {
+        logd << "starting eventloop..." << std::endl;
+    }
+
+    while (m_running) {
+        processEvents();
+    }
+
+    logd << "exited event loop" << std::endl;
+}
 
 RENGINE_END_NAMESPACE

--- a/include/backend/backend.h
+++ b/include/backend/backend.h
@@ -35,7 +35,7 @@ public:
 
     static Backend *get();
 
-    virtual void quit() = 0;
+    void quit();
     void run();
     virtual void processEvents() = 0;
     virtual Surface *createSurface(SurfaceInterface *) = 0;
@@ -43,6 +43,11 @@ public:
 
     bool m_running;
 };
+
+inline void Backend::quit()
+{
+    m_running = false;
+}
 
 inline void Backend::run()
 {

--- a/include/backend/qt/qtbackend.h
+++ b/include/backend/qt/qtbackend.h
@@ -54,7 +54,6 @@ public:
         logd << std::endl;
     }
 
-    void quit() override { m_running = false; }
     void processEvents() override;
     Surface *createSurface(SurfaceInterface *iface) override;
     Renderer *createRenderer(Surface *surface) override;

--- a/include/backend/qt/qtbackend.h
+++ b/include/backend/qt/qtbackend.h
@@ -49,20 +49,17 @@ class QtBackend : public Backend
 public:
 
     QtBackend()
-        : app(hack_argc(), hack_argv()), exited(false)
+        : app(hack_argc(), hack_argv())
     {
         logd << std::endl;
     }
 
-    void quit() override { exited = true; app.quit(); }
-    void run() override;
-    void processEvents();
+    void quit() override { m_running = false; }
+    void processEvents() override;
     Surface *createSurface(SurfaceInterface *iface) override;
     Renderer *createRenderer(Surface *surface) override;
 
     QGuiApplication app;
-
-    bool exited;
 };
 
 class QtWindow : public QWindow
@@ -105,9 +102,10 @@ public:
 class QtSurface : public Surface
 {
 public:
-    QtSurface(SurfaceInterface *iface)
+    QtSurface(SurfaceInterface *iface, QtBackend *backend)
     : window(this)
     , iface(iface)
+    , backend(backend)
     {
         setSurfaceToInterface(iface);
         logi << "QtBackend::Surface created with interface=" << iface << std::endl;
@@ -159,6 +157,7 @@ public:
     QOpenGLContext context;
     QtWindow window;
     SurfaceInterface *iface;
+    QtBackend *backend;
 };
 
 inline void QtBackend::processEvents()
@@ -167,21 +166,11 @@ inline void QtBackend::processEvents()
     QCoreApplication::sendPostedEvents(0, QEvent::DeferredDelete);
 }
 
-inline void QtBackend::run()
-{
-    logd << "starting eventloop..." << std::endl;
-    if (exited)
-        logd << "quit() already called, not starting eventloop.." << std::endl;
-    if (!exited)
-        app.exec();
-    logd << "exited event loop" << std::endl;
-}
-
 inline Surface *QtBackend::createSurface(SurfaceInterface *iface)
 {
     logd << __PRETTY_FUNCTION__ << iface << std::endl;
     assert(iface);
-    QtSurface *s = new QtSurface(iface);
+    QtSurface *s = new QtSurface(iface, this);
     return s;
 }
 
@@ -221,6 +210,9 @@ inline bool QtWindow::event(QEvent *e)
         logd << "onRender completed" << std::endl;
     }
 #endif
+    if (e->type() == QEvent::Close) {
+        s->backend->m_running = false;
+    }
     return QWindow::event(e);
 }
 

--- a/include/backend/sdl/sdlbackend.h
+++ b/include/backend/sdl/sdlbackend.h
@@ -46,9 +46,7 @@ public:
     {
         if (SDL_Init(SDL_INIT_VIDEO) < 0)
             sdlbackend_die("Unable to initialize SDL");
-#ifdef RENGINE_LOG_INFO
-        std::cout << "SdlBackend: created..." << std::endl;
-#endif
+        logi << "SdlBackend: created..." << std::endl;
     }
 
     ~SdlBackend()
@@ -110,9 +108,7 @@ public:
     , iface(iface)
     {
         setSurfaceToInterface(iface);
-#ifdef RENGINE_LOG_INFO
-        std::cout << "SdlBackend::Surface created with interface=" << iface << std::endl;
-#endif
+        logi << "SdlBackend::Surface created with interface=" << iface << std::endl;
         requestRender();
     }
 
@@ -120,7 +116,7 @@ public:
         static bool warned = false;
         if (!warned) {
             warned = true;
-            std::cerr << "makeCurrent: stub" << std::endl;
+            logw << "makeCurrent: stub" << std::endl;
         }
         return true;
     }
@@ -222,7 +218,7 @@ inline void SdlBackend::processEvents()
                 break;
             }
             default: {
-                // std::cerr << "unknown event.type " << event.type << std::endl;
+                // logw << "unknown event.type " << event.type << std::endl;
             }
         }
     }

--- a/include/backend/sdl/sdlbackend.h
+++ b/include/backend/sdl/sdlbackend.h
@@ -51,7 +51,11 @@ public:
 #endif
     }
 
-    void quit() override { SDL_Quit(); }
+    ~SdlBackend()
+    {
+        SDL_Quit();
+    }
+
     void processEvents() override;
     Surface *createSurface(SurfaceInterface *iface) override;
     Renderer *createRenderer(Surface *surface) override;

--- a/include/backend/sfhwc/sfhwc.h
+++ b/include/backend/sfhwc/sfhwc.h
@@ -81,7 +81,7 @@ public:
 	SfHwcBackend();
 
     void quit() override;
-    void run() override;
+    void processEvents() override;
 
     void updateTouch();
 

--- a/include/backend/sfhwc/sfhwc.h
+++ b/include/backend/sfhwc/sfhwc.h
@@ -80,7 +80,6 @@ class SfHwcBackend : public Backend, public hwc_procs_t
 public:
 	SfHwcBackend();
 
-    void quit() override;
     void processEvents() override;
 
     void updateTouch();

--- a/include/backend/sfhwc/sfhwcbackend.h
+++ b/include/backend/sfhwc/sfhwcbackend.h
@@ -170,19 +170,13 @@ inline SfHwcBackend::SfHwcBackend()
     logi << " - # frames predicted .: " << m_touchPrediction << std::endl;
 }
 
-inline void SfHwcBackend::run()
+inline void SfHwcBackend::processEvents()
 {
-    logi << __PRETTY_FUNCTION__
-         << "; running=" << m_running
-         << "; surface=" << surface
-         << "; iface=" << (surface ? surface->m_iface : nullptr)
-         << std::endl;
-
     timeval halfAFrame;
     halfAFrame.tv_sec = 0;
     halfAFrame.tv_usec = 8 * 1000;
 
-    while (m_running && surface && surface->m_iface) {
+    if (surface && surface->m_iface) {
         surface->m_iface->onRender();
 
         updateTouch();

--- a/include/backend/sfhwc/sfhwcbackend.h
+++ b/include/backend/sfhwc/sfhwcbackend.h
@@ -30,12 +30,6 @@
 
 RENGINE_BEGIN_NAMESPACE
 
-void SfHwcBackend::quit()
-{
-    logi << __PRETTY_FUNCTION__ << std::endl;
-    m_running = false;
-}
-
 Surface *SfHwcBackend::createSurface(SurfaceInterface *iface)
 {
     // We only allow one surface, the output window..


### PR DESCRIPTION
Instead of always owning the main loop, we now offer up a way to "crank" the event loop by hand. This is useful for embedding-type scenarios, where we may want to stick rengine inside something else.
